### PR TITLE
Fix failing CI pipeline

### DIFF
--- a/.github/workflows/django.yml
+++ b/.github/workflows/django.yml
@@ -22,6 +22,6 @@ jobs:
         with:
           poetry-version: ${{ matrix.poetry-version }}
       - name: Install dependencies
-        run: poetry install
+        run: poetry install --no-root
       - name: Run tests
         run: poetry run python manage.py test

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ WORKDIR /code
 COPY poetry.lock pyproject.toml ./
 
 RUN poetry config virtualenvs.create false && \
-    poetry install --only main --no-interaction --no-ansi
+    poetry install --only main --no-interaction --no-ansi --no-root
 
 COPY . .
 


### PR DESCRIPTION
Poetry was trying to install the project itself as a package, but this is a Django project without a proper package structure. Adding --no-root flag tells Poetry to only install dependencies without trying to install the project itself.

This fixes both the CI workflow and the Docker build.