### PR TITLE
Add additional Alpine build dependencies for Pillow

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.11-alpine
 
-RUN apk add --no-cache build-base python3-dev py-pip jpeg-dev zlib zlib-dev musl-dev libffi-dev freetype-dev gettext && \
+RUN apk add --no-cache build-base python3-dev py-pip jpeg-dev zlib zlib-dev musl-dev libffi-dev freetype-dev gettext \
+    lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev harfbuzz-dev fribidi-dev && \
     pip install -U pip poetry
 
 ENV CFLAGS="$CFLAGS -L/lib"


### PR DESCRIPTION
Add lcms2-dev, openjpeg-dev, tiff-dev, tk-dev, tcl-dev, harfbuzz-dev, and fribidi-dev packages to support full Pillow compilation in Alpine. These dependencies are required for image processing features.