### PR TITLE
Pin Poetry version to 1.3.2 in Dockerfile for consistency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,8 @@ FROM python:3.11-alpine
 
 RUN apk add --no-cache build-base python3-dev py-pip jpeg-dev zlib zlib-dev musl-dev libffi-dev freetype-dev gettext \
     lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev harfbuzz-dev fribidi-dev && \
-    pip install -U pip poetry
+    pip install -U pip && \
+    pip install poetry==1.3.2
 
 ENV CFLAGS="$CFLAGS -L/lib"
 


### PR DESCRIPTION
Use the same Poetry version (1.3.2) in the Dockerfile as in the GitHub Actions workflow to ensure compatibility with poetry.lock. Installing the latest Poetry version (2.x) via pip caused compatibility issues with the lock file created with Poetry 1.x.