### PR TITLE
Install cffi before Poetry to fix dependency installation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM python:3.11-alpine
 RUN apk add --no-cache build-base python3-dev py-pip jpeg-dev zlib zlib-dev musl-dev libffi-dev freetype-dev gettext \
     lcms2-dev openjpeg-dev tiff-dev tk-dev tcl-dev harfbuzz-dev fribidi-dev && \
     pip install -U pip && \
+    pip install cffi && \
     pip install poetry==1.3.2
 
 ENV CFLAGS="$CFLAGS -L/lib"


### PR DESCRIPTION
Poetry 1.3.2 requires cffi to be installed before it can properly install dependencies. Without cffi, the installation fails with: ModuleNotFoundError: No module named '_cffi_backend'

This ensures cffi is available when Poetry runs.